### PR TITLE
feat(dkms): add dkms build

### DIFF
--- a/Makefile.dkms
+++ b/Makefile.dkms
@@ -1,0 +1,27 @@
+modname := 8812au
+DKMS := dkms
+modver := 5.1.5
+
+# directory in which generated files are stored
+DKMS_DEST := /usr/src/$(modname)-$(modver)
+
+all: install
+
+src_install:
+	make clean
+	mkdir -p '$(DKMS_DEST)'
+	cp -r dkms.conf Kconfig Makefile.dkms Makefile platform core hal include os_dep '$(DKMS_DEST)'
+	cp Makefile '$(DKMS_DEST)/Makefile'
+	sed 's/#MODULE_VERSION#/$(modver)/' dkms.conf > '$(DKMS_DEST)/dkms.conf'
+
+build: src_install
+	$(DKMS) add -m $(modname) -v $(modver) 2>/dev/null || true
+	$(DKMS) build -m $(modname) -v $(modver)
+
+install: build
+	$(DKMS) install -m $(modname) -v $(modver)
+
+uninstall:
+	$(DKMS) remove -m $(modname) -v $(modver) --all
+
+.PHONY: all src_install build install uninstall

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,11 @@ make
 sudo make install
 ```
 
+# Preffered dkms install
+```
+make -f Makefile.dkms install
+```
+
 Linux kernel driver for rtl8812au/rtl8821au/rtl8811au USB WiFi chipsets.
 
 Experimental build of driver-5.1.5 branch from uminokoe/rtl8812AU, with some

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="8812au"
+PACKAGE_VERSION="#MODULE_VERSION#"
+MAKE="'make'  KVER=${kernelver} KSRC=/lib/modules/${kernelver}/build"
+CLEAN="make clean"
+BUILT_MODULE_NAME[0]="8812au"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/net"
+AUTOINSTALL="yes"


### PR DESCRIPTION
For Ubuntu or other distro builds, the kernels are often upgraded. DKMS build is useful in these scenarios.